### PR TITLE
feat(asg): ⬆️ update EC2 instance when launching template updates

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -10,7 +10,11 @@ resource "aws_autoscaling_group" "main" {
 
   launch_template {
     id      = aws_launch_template.main.id
-    version = "$Latest"
+    version = aws_launch_template.main.latest_version // explicitly set to latest version
+  }
+
+  instance_refresh {
+    strategy = "Rolling"
   }
 
   dynamic "tag" {


### PR DESCRIPTION
When using HA mode (auto-scaling group) if the user updates a parameter of the launch templates like instance size or security group the instance doesn't get updated. 
With this change, the instance will restart to take into account the change.